### PR TITLE
Update Mongo and Redis dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented here.
 
-## [Unreleased]
+## 2023-12-09
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented here.
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade `redis` and `mongo` containers to newer versions. Old Mongo databases are not compatible with the new version. Before upgrade, do a backup with `mre dumpdb`, remove old database in `data/mongodb`. After upgrade, restore database with `mre restoredb`.
+
+### Contributors
+
+- @zeronounours
+
 ## 2023-12-07
 
 ### Added

--- a/docker-compose.microservices.base.yml
+++ b/docker-compose.microservices.base.yml
@@ -4,7 +4,7 @@ services:
   # Redis
   ###############################################################################
   redis:
-    image: redis:5
+    image: redis:7
     expose:
       - '$REDIS_PORT'
     volumes:
@@ -19,7 +19,7 @@ services:
   # Mongo
   ###############################################################################
   mongo:
-    image: mongo:4.4
+    image: mongo:7
     command: --quiet
     expose:
       - '$MONGO_PORT'


### PR DESCRIPTION
Redis image (version 5) is not supported anymore (last update more than 1 year ago). Mongo image (version 4.4) support is about to be dropped too (last suppported version).

This updates both dependencies.

**Upgrade process**:

- mongo DB needs to be dumped/backuped
- delete any previous database file (in `./data/mongodb`)
- restore backup after upgrade.

Doing the upgrade before dumping won't delete any data: mongo container stops  if it sees files from older versions.


Redis client needs to be modified with newer versions because it does not support both MONITOR and other commands on the same connection (see  https://github.com/redis/node-redis/issues/1627)