### PR TITLE
Fix few issues in Landlord webapp settings page

### DIFF
--- a/webapps/landlord/src/components/organization/BillingForm.js
+++ b/webapps/landlord/src/components/organization/BillingForm.js
@@ -14,27 +14,33 @@ import { observer } from 'mobx-react-lite';
 import { StoreContext } from '../../store';
 import useTranslation from 'next-translate/useTranslation';
 
-const validationSchema = Yup.object().shape({
-  vatNumber: Yup.string(),
-  bankName: Yup.string().required(),
-  iban: Yup.string().required(),
-  contact: Yup.string().required(),
-  email: Yup.string().email().required(),
-  phone1: Yup.string().required(),
-  phone2: Yup.string(),
-  address: Yup.object().shape({
-    street1: Yup.string().required(),
-    street2: Yup.string(),
-    city: Yup.string().required(),
-    zipCode: Yup.string().required(),
-    state: Yup.string(),
-    country: Yup.string().required(),
-  }),
-});
-
 const BillingForm = observer(({ onSubmit }) => {
   const store = useContext(StoreContext);
   const { t } = useTranslation('common');
+
+  const validationSchema = Yup.object().shape({
+    vatNumber: store.organization.selected?.isCompany
+      ? Yup.string().required()
+      : Yup.string(),
+    bankName: store.organization.selected?.isCompany
+      ? Yup.string().required()
+      : Yup.string(),
+    iban: store.organization.selected?.isCompany
+      ? Yup.string().required()
+      : Yup.string(),
+    contact: Yup.string().required(),
+    email: Yup.string().email().required(),
+    phone1: Yup.string().required(),
+    phone2: Yup.string(),
+    address: Yup.object().shape({
+      street1: Yup.string().required(),
+      street2: Yup.string(),
+      city: Yup.string().required(),
+      zipCode: Yup.string().required(),
+      state: Yup.string(),
+      country: Yup.string().required(),
+    }),
+  });
 
   const initialValues = useMemo(
     () => ({
@@ -91,14 +97,14 @@ const BillingForm = observer(({ onSubmit }) => {
       {({ isSubmitting }) => {
         return (
           <Form autoComplete="off">
-            {store.organization.selected &&
-              store.organization.selected.isCompany && (
-                <Section label={t('Billing information')}>
+            <Section label={t('Billing information')}>
+              {store.organization.selected &&
+                store.organization.selected.isCompany && (
                   <TextField label={t('VAT number')} name="vatNumber" />
-                  <TextField label={t('Bank name')} name="bankName" />
-                  <TextField label={t('IBAN')} name="iban" />
-                </Section>
-              )}
+                )}
+              <TextField label={t('Bank name')} name="bankName" />
+              <TextField label={t('IBAN')} name="iban" />
+            </Section>
             <Section label={t('Contact')}>
               <ContactField />
             </Section>

--- a/webapps/landlord/src/components/organization/ThirdPartiesForm.js
+++ b/webapps/landlord/src/components/organization/ThirdPartiesForm.js
@@ -103,18 +103,22 @@ const ThirdPartiesForm = observer(({ onSubmit }) => {
 
   const initialValues = useMemo(() => {
     let emailDeliveryServiceName;
-    let fromEmail;
-    let replyToEmail;
+    let fromEmail = store.organization.selected?.contacts?.[0]?.email || '';
+    let replyToEmail = store.organization.selected?.contacts?.[0]?.email || '';
 
     if (store.organization.selected.thirdParties?.gmail?.selected) {
       emailDeliveryServiceName = 'gmail';
-      fromEmail = store.organization.selected?.contacts?.[0]?.email || '';
-      replyToEmail = store.organization.selected?.contacts?.[0]?.email || '';
+      fromEmail =
+        store.organization.selected.thirdParties?.gmail?.fromEmail || '';
+      replyToEmail =
+        store.organization.selected.thirdParties?.gmail?.replyToEmail || '';
     }
     else if (store.organization.selected.thirdParties?.smtp?.selected) {
       emailDeliveryServiceName = 'smtp';
-      fromEmail = store.organization.selected?.contacts?.[0]?.email || '';
-      replyToEmail = store.organization.selected?.contacts?.[0]?.email || '';
+      fromEmail =
+        store.organization.selected.thirdParties?.smtp?.fromEmail || '';
+      replyToEmail =
+        store.organization.selected.thirdParties?.smtp?.replyToEmail || '';
     }
     else if (store.organization.selected.thirdParties?.mailgun?.selected) {
       emailDeliveryServiceName = 'mailgun';


### PR DESCRIPTION
This PR fix two issues:
- Issue #150 which prevents submission of the BillingForm when the organization is a personal account
- Awkward behaviors of `fromEmail` and `replyToEmail` for Gmail & SMTP

The latter is already described in the issue.

The former is an issue with the fields in the Third Party page. For Gmail & SMTP, both fields are always initialized with the first billing contact, no matter what was the previous setting. With this PR, the fields are filled with the first billing contact if no configuration was set or the previously configured values.