### PR TITLE
Fix SMTP authentication

### DIFF
--- a/services/common/models/realm.js
+++ b/services/common/models/realm.js
@@ -66,7 +66,7 @@ const RealmSchema = mongoose.Schema({
       server: String,
       port: Number,
       secure: Boolean,
-      authentification: Boolean,
+      authentication: Boolean,
       username: String,
       password: String,
       fromEmail: String,

--- a/services/typed-common/src/collections/realm.ts
+++ b/services/typed-common/src/collections/realm.ts
@@ -67,7 +67,7 @@ const RealmSchema = new mongoose.Schema<CollectionTypes.Realm>({
       server: String,
       port: Number,
       secure: Boolean,
-      authentification: Boolean,
+      authentication: Boolean,
       username: String,
       password: String,
       fromEmail: String,


### PR DESCRIPTION
Due to a key error in the model, the SMTP authentication does not work, even when configured.