### PR TITLE
fix: terminate lease dialog error message

### DIFF
--- a/webapps/landlord/locales/en/common.json
+++ b/webapps/landlord/locales/en/common.json
@@ -382,6 +382,7 @@
   "Terminated": "Terminated",
   "Termination": "Termination",
   "Termination date": "Termination date",
+  "Termination date is out of the contract time frame": "Termination date is out of the contract time frame",
   "Text documents": "Text documents",
   "Text template": "Text template",
   "The contacts will receive the invoices and will be able to access the tenant's portal": "The contacts will receive the invoices and will be able to access the tenant's portal",

--- a/webapps/landlord/locales/fr-FR/common.json
+++ b/webapps/landlord/locales/fr-FR/common.json
@@ -382,6 +382,7 @@
   "Terminated": "Résilié",
   "Termination": "Résiliation",
   "Termination date": "Date de résiliation",
+  "Termination date is out of the contract time frame": "La date de résiliation ne correspond pas aux dates du bail",
   "Text documents": "Documents texte",
   "Text template": "Modèle de texte",
   "The contacts will receive the invoices and will be able to access the tenant's portal": "Les contacts recevront les factures et pourront accéder au portail du locataire",

--- a/webapps/landlord/src/components/tenants/TerminateLeaseDialog.js
+++ b/webapps/landlord/src/components/tenants/TerminateLeaseDialog.js
@@ -121,7 +121,9 @@ export default function TerminateLeaseDialog({ open, setOpen, tenantList }) {
           case 403:
             return toast.error(t('You are not allowed to update the tenant'));
           case 409:
-            return toast.error(t('The tenant already exists'));
+            return toast.error(
+              t('Termination date is out of the contract time frame')
+            );
           default:
             return toast.error(t('Something went wrong'));
         }


### PR DESCRIPTION
# What/Why
Fixed the wording of an error message. The error message in the toast was misleading.

![fix-error-message](https://github.com/user-attachments/assets/fc44e0c8-5e9d-4de7-9d96-cda49d21e53c)


# How to reproduce:

in dev, 

1. get to the tenant page http://localhost:8080/landlord/demo/tenants/ and pick any one
2. click on `Terminate`
3. in the "Terminate a lease dialog", pick a date outside of  the contract lease, let's say 01/01/1970
4. check the error message in the toast at the  bottom the window
