### PR TITLE
Issue #74 - Zip Code to Be Optional and Not Mandatory 

### DIFF
--- a/types/src/common/collections.ts
+++ b/types/src/common/collections.ts
@@ -11,7 +11,7 @@ export namespace CollectionTypes {
   export type PartAddress = {
     street1: string;
     street2?: string;
-    zipCode: string;
+    zipCode?: string;
     city: string;
     state?: string;
     country: string;
@@ -232,7 +232,7 @@ export namespace CollectionTypes {
     capital: number;
     street1: string;
     street2: string;
-    zipCode: string;
+    zipCode?: string;
     city: string;
     country: string;
     contacts: {


### PR DESCRIPTION
This issue is fixed. I inserted '?' in the type script file so the input field was set to be optional and not mandatory. 